### PR TITLE
fixed date dt handling

### DIFF
--- a/pages/student/setting.php
+++ b/pages/student/setting.php
@@ -13,8 +13,7 @@ $student = fetch(
 if (isset($_POST["save-changed"])) {
     $city = htmlspecialchars(ucwords($_POST['city']));
     $phone_number = $_POST['phone_number'];
-    $date_of_birth = $_POST['date_of_birth'];
-    var_dump($date_of_birth);
+    $date_of_birth = !empty($_POST['date_of_birth']) ? "'" . $_POST['date_of_birth'] . "'" : "NULL"; // wrap $date_of_birth correctly
     $name = $_POST['name'];
     
     $sql2 = execDML(
@@ -25,7 +24,7 @@ if (isset($_POST["save-changed"])) {
             phone_number = '$phone_number'
         WHERE id = $studentId"
     );
-
+    
     if ($sql2 > 0) {
         echo "Update berhasil!";
     } else {


### PR DESCRIPTION
value $date_of_birth sebelumnya di wrap pake ""  by default, mungkin karena yang lain di wrap pake ' ', maka ngak kehitung kali??makanya dia kehitung ' ' dan by default jadi '2018' <- ini gak valid jadi error. ini juga terjadi kalo user clear inputan tersebut dan perbaiki.

fix nya di wrap properly pakai ' ', baru add kondisi kalau dia kosong jadikan "NULL" by default